### PR TITLE
Can not assume "clean" nml data

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -113,6 +113,11 @@ rule calc_efpl:
     params:
         data_start =lambda wc: [chunk *128 for chunk in config['datasets'][wc.ident]['chunk']],
         data_size = lambda wc: config['datasets'][wc.ident]['size']
+    threads:
+        20
+    resources:
+        partition=cpu,
+        time='00:30:00',
     conda:
         'environment.yml'
     shell:

--- a/Snakefile
+++ b/Snakefile
@@ -99,8 +99,7 @@ rule apply_watershed_on_ICS_probability:
         ' --probfile {input}' +
         ' --chunk {params.chunk} --offset 0 0 0 --size {params.size}' +
         ' --outlabels {output}' +
-        ' --ThrRng 0.5 0.999 0.1' +
-        ' --ThrHi 0.95 0.99 0.995 0.999 0.99925 0.9995 0.99975 0.9999 0.99995 0.99999 --dpW'
+        ' --ThrRngLogit 0 16 1 --dpW'
 
 rule calc_efpl:
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -4,6 +4,8 @@
 configfile: "config.yml"
 root = config['local_data_path']
 
+gpu = "GPU"
+gres = ""
 
 # Workaround for rest2skel; Better: add all shell scripts to PATH environment variable via setup tools ...
 if 'emdrp' in workflow.modules.keys():
@@ -57,7 +59,7 @@ rule merge_predicted_probabilities:
         expand(root + '/data_out/{{ident}}_{{type}}_{{extra}}_{replicate}.0_probs.h5',
             replicate =range(4)),
     wildcard_constraints:
-        ident="(M0007)|(M0027)",
+        ident="(M0007)|(M0027)|(M0007sqz)",
         type="[^_]+",
         extra="[^_]+",
     params:
@@ -89,7 +91,7 @@ rule apply_watershed_on_ICS_probability:
         chunk = lambda wc: config['datasets'][wc.ident]['chunk'],
     resources:
         time='24:00:00', # the runtime depends on the number of labels
-        partition="p.gpu", # since cpu queue is full
+        partition=gpu, # since cpu queue is full
         mem="64000",
         cpus_per_task="2",
     conda:

--- a/Snakefile
+++ b/Snakefile
@@ -5,6 +5,7 @@ configfile: "config.yml"
 root = config['local_data_path']
 
 gpu = "GPU"
+cpu = "CPU"
 gres = ""
 
 # Workaround for rest2skel; Better: add all shell scripts to PATH environment variable via setup tools ...
@@ -79,7 +80,7 @@ rule merge_predicted_probabilities:
         ' --chunk {params.chunk}' +
         ' --size {params.size}' +
         ' --types ICS ECS MEM --ops mean' + 
-        ' --sigmoid --dpM --dpmergeProbs-verbose'
+        ' --sigmoid --dpM --dpMergeProbs-verbose'
 
 rule apply_watershed_on_ICS_probability:
     output:
@@ -91,7 +92,7 @@ rule apply_watershed_on_ICS_probability:
         chunk = lambda wc: config['datasets'][wc.ident]['chunk'],
     resources:
         time='24:00:00', # the runtime depends on the number of labels
-        partition=gpu, # since cpu queue is full
+        partition=cpu, 
         mem="64000",
         cpus_per_task="2",
     conda:
@@ -101,7 +102,7 @@ rule apply_watershed_on_ICS_probability:
         ' --probfile {input}' +
         ' --chunk {params.chunk} --offset 0 0 0 --size {params.size}' +
         ' --outlabels {output}' +
-        ' --ThrRngLogit 0 16 1 --dpW'
+        ' --ThrRngsLogit 0 16 1 --dpW'
 
 rule calc_efpl:
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -76,7 +76,8 @@ rule merge_predicted_probabilities:
         ' --outprobs {output}' +
         ' --chunk {params.chunk}' +
         ' --size {params.size}' +
-        ' --types ICS ECS MEM --ops mean min --dpMergeProbs-verbose'
+        ' --types ICS ECS MEM --ops mean' + 
+        ' --sigmoid --dpM --dpmergeProbs-verbose'
 
 rule apply_watershed_on_ICS_probability:
     output:

--- a/config.yml
+++ b/config.yml
@@ -6,19 +6,19 @@ datasets:
     chunk: [16, 17, 0] # xyz
     EM_mean: 152
     EM_std: 60.5
-    original_volume:  /soma/soma_fs/cne/pwatkins/cne_nas_bkp/from_externals/ECS_paper/M0007_33_39x35x7chunks_Forder.h5
-    skeleton: /soma/soma_fs/cne/pwatkins/cne_nas_bkp/from_externals/ECS_paper/skeletons/M0007_33_dense_skels.152.nml
+    original_volume:  /soma/soma_fs/cne/pwatkins/from_externals/ECS_paper/M0007_33_39x35x7chunks_Forder.h5
+    skeleton: /soma/soma_fs/cne/pwatkins/from_externals/ECS_paper/skeletons/M0007_33_dense_skels.152.nml
   M0027:
     size: [1024, 1024, 512] #xyz
     chunk: [12, 14, 2] # xyz
     EM_mean: 159
     EM_std: 50
-    original_volume:  /soma/soma_fs/cne/pwatkins/cne_nas_bkp/from_externals/ECS_paper/M0027_11_33x37x7chunks_Forder.h5
-    skeleton: /soma/soma_fs/cne/pwatkins/cne_nas_bkp/from_externals/ECS_paper/skeletons/M0027_11_dense_skels.186.nml
+    original_volume:  /soma/soma_fs/cne/pwatkins/from_externals/ECS_paper/M0027_11_33x37x7chunks_Forder.h5
+    skeleton: /soma/soma_fs/cne/pwatkins/from_externals/ECS_paper/skeletons/M0027_11_dense_skels.186.nml
   test:
     size: [1024, 1024, 512] # xyz
     chunk: [0, 0, 0] #xyz
     EM_mean: 152
     EM_std: 60.5
-    original_volume:  /soma/soma_fs/cne/pwatkins/cne_nas_bkp/from_externals/ECS_paper/M0007_33_39x35x7chunks_Forder.h5
-    skeleton: /soma/soma_fs/cne/pwatkins/cne_nas_bkp/from_externals/ECS_paper/skeletons/M0007_33_dense_skels.152.nml
+    original_volume:  /soma/soma_fs/cne/pwatkins/from_externals/ECS_paper/M0007_33_39x35x7chunks_Forder.h5
+    skeleton: /soma/soma_fs/cne/pwatkins/from_externals/ECS_paper/skeletons/M0007_33_dense_skels.152.nml

--- a/emdrp/emdrp/scripts/calculate_efpl.py
+++ b/emdrp/emdrp/scripts/calculate_efpl.py
@@ -1,0 +1,26 @@
+from emdrp.utils.efpl import calc_supervoxel_eftpl
+import numpy as np
+
+from argparse import ArgumentParser
+
+def parse_args():
+    parser = ArgumentParser()
+    
+    parser.add_argument('--csv_results', type=str, help="file path for result csv")
+    parser.add_argument('--nml_file', type=str, help="file path for nml file")
+    parser.add_argument('--h5_file', type=str, help="file path for hdf5 file")
+    parser.add_argument('--size', type=int, nargs='+', help="size of region of interest")
+    parser.add_argument('--dataset_start', type=int, nargs='+', help="start indices of region of interest")
+
+    return parser, parser.parse_args()
+
+def main():
+    parser, args = parse_args()
+
+    eftpl, params = calc_supervoxel_eftpl(args.nml_file, args.h5_file, size=args.size, dset_start=args.dataset_start)
+
+    results = np.asarray([eftpl, params ])
+    np.savetxt(args.csv_results, results.transpose(), fmt='%s', delimiter=',', header=','.join(['eftpl', 'param']))
+
+if __name__ == '__main__':
+    main()

--- a/emdrp/emdrp/utils/efpl.py
+++ b/emdrp/emdrp/utils/efpl.py
@@ -94,7 +94,7 @@ def calc_eftpl(nml, Vlbls, dataset_start=np.zeros((1,3), dtype=int), verbose=Fal
         edges[col] = edges['edges'].apply(lambda location: location[n])
 
     edge_is_outside = edges.source_node.isin(node_id_outside) | edges.target_node.isin(node_id_outside)
-    print(f'Warning: {np.sum(edge_is_outside)} edges lead to node outside the ROI')
+    print(f'Warning: {np.sum(edge_is_outside)} edges lead to nodes outside the ROI')
 
     edges = edges[np.logical_not(edge_is_outside)]    
     edges = edges.drop(columns=['edges'])

--- a/emdrp/emdrp/utils/efpl.py
+++ b/emdrp/emdrp/utils/efpl.py
@@ -66,7 +66,8 @@ def calc_eftpl(nml, Vlbls, dataset_start=np.zeros((1,3), dtype=int), verbose=Fal
         np.any(nodes[idx_columns] >= np.array([[Vlbls.shape[ax_idx] for ax_idx in hdf5_dim_idcs]]), axis=1),
         np.any(nodes[idx_columns] < 0, axis=1))
 
-    print('Warning: Remove {} nodes outside the ROI '.format(np.sum(node_is_outside_volume)))
+    if np.any(node_is_outside_volume):
+        print('Warning: Remove {} nodes outside the ROI '.format(np.sum(node_is_outside_volume)))
 
     node_id_outside = nodes[node_is_outside_volume].id
 
@@ -85,7 +86,8 @@ def calc_eftpl(nml, Vlbls, dataset_start=np.zeros((1,3), dtype=int), verbose=Fal
 
     edges = edges.explode('edges')
     edge_is_nan = edges['edges'].isna()
-    print(f'Warning: {np.sum(edge_is_nan)} edges have nan values!')
+    if np.any(edge_is_nan):
+        print(f'Warning: {np.sum(edge_is_nan)} edges have nan values!')
 
     edges = edges[np.logical_not(edges['edges'].isna())]
 
@@ -94,7 +96,8 @@ def calc_eftpl(nml, Vlbls, dataset_start=np.zeros((1,3), dtype=int), verbose=Fal
         edges[col] = edges['edges'].apply(lambda location: location[n])
 
     edge_is_outside = edges.source_node.isin(node_id_outside) | edges.target_node.isin(node_id_outside)
-    print(f'Warning: {np.sum(edge_is_outside)} edges lead to nodes outside the ROI')
+    if np.any(edge_is_outside):
+        print(f'Warning: {np.sum(edge_is_outside)} edges lead to nodes outside the ROI')
 
     edges = edges[np.logical_not(edge_is_outside)]    
     edges = edges.drop(columns=['edges'])

--- a/emdrp/emdrp/utils/efpl.py
+++ b/emdrp/emdrp/utils/efpl.py
@@ -1,12 +1,46 @@
 import numpy as np
 import pandas as pd
 import wknml
+import h5py
 
 KNOSSOS_BASE =  np.ones((1, 3), dtype=int)
 NML_DIM_ORDER = 'xyz'
 HDF5_DIM_ORDER = 'zyx'
 
 HDF5_BACKGROUND_LABEL = 0
+
+def calc_supervoxel_eftpl(nml_filepath, h5_filepath, dset_vals=None, dset_folder='with_background', dset_suffix='labels',
+    size=None, dset_start=np.zeros((1,3), dtype=int), 
+    ):
+
+    with open(nml_filepath, "rb") as f:
+        nml = wknml.parse_nml(f)
+
+    if dset_vals is None:
+        with h5py.File(h5_filepath, 'r') as h5file:
+            dset = h5file[dset_folder]
+            dset_vals = [str(k) for k in dset.keys()]
+
+    eftpl = np.zeros(len(dset_vals))
+
+    h5_dim_idcs = [HDF5_DIM_ORDER.index(ax) for ax in 'xyz']
+
+    selection = None
+    if size is not None:
+        selection = tuple(slice(dset_start[ax],dset_start[ax]+size[ax]) for ax in h5_dim_idcs)
+
+    for i, dset_val in enumerate(dset_vals):
+        with h5py.File(h5_filepath, 'r') as h5file:
+            dset = h5file['/'.join([dset_folder, dset_val, dset_suffix])]
+            if size is None:
+                Vlbls = dset[:]
+            else:
+                Vlbls = np.zeros(tuple(size[ax] for ax in h5_dim_idcs), dtype=dset.dtype)
+                dset.read_direct(Vlbls, selection)
+        eftpl[i] = calc_eftpl(nml, Vlbls, dset_start)
+
+    return eftpl, dset_vals
+
 
 def calc_eftpl(nml, Vlbls, dataset_start=np.zeros((1,3), dtype=int), verbose=False):
     
@@ -24,6 +58,20 @@ def calc_eftpl(nml, Vlbls, dataset_start=np.zeros((1,3), dtype=int), verbose=Fal
 
     nodes[idx_columns] -= (dataset_start + KNOSSOS_BASE)
 
+    # Comment(erjel): That moment when you wrote an on-point pipeline and realize that you
+    # have to deal with messy data ...
+    hdf5_dim_idcs = np.array([NML_DIM_ORDER.index(ax) for ax in HDF5_DIM_ORDER])
+
+    node_is_outside_volume = np.logical_or(
+        np.any(nodes[idx_columns] >= np.array([[Vlbls.shape[ax_idx] for ax_idx in hdf5_dim_idcs]]), axis=1),
+        np.any(nodes[idx_columns] < 0, axis=1))
+
+    print('Warning: Remove {} nodes outside the ROI '.format(np.sum(node_is_outside_volume)))
+
+    node_id_outside = nodes[node_is_outside_volume].id
+
+    nodes = nodes[np.logical_not(node_is_outside_volume)]
+
     nodes['label'] = Vlbls[tuple(nodes[f'idx_{ax}'] for ax in HDF5_DIM_ORDER)]
 
     position_colums = [f'position_{ax}' for ax in NML_DIM_ORDER]
@@ -36,11 +84,19 @@ def calc_eftpl(nml, Vlbls, dataset_start=np.zeros((1,3), dtype=int), verbose=Fal
     edges = edges.rename(columns={"id": "tree_id"})
 
     edges = edges.explode('edges')
+    edge_is_nan = edges['edges'].isna()
+    print(f'Warning: {np.sum(edge_is_nan)} edges have nan values!')
+
+    edges = edges[np.logical_not(edges['edges'].isna())]
 
     new_col_list = ['source_node','target_node']
     for n ,col in enumerate(new_col_list):
         edges[col] = edges['edges'].apply(lambda location: location[n])
 
+    edge_is_outside = edges.source_node.isin(node_id_outside) | edges.target_node.isin(node_id_outside)
+    print(f'Warning: {np.sum(edge_is_outside)} edges lead to node outside the ROI')
+
+    edges = edges[np.logical_not(edge_is_outside)]    
     edges = edges.drop(columns=['edges'])
 
     ### Merge nodes information into edge data and calculate path lengths

--- a/tests/emdrp/emdrp/utils/test_efpl.py
+++ b/tests/emdrp/emdrp/utils/test_efpl.py
@@ -1,9 +1,62 @@
 from emdrp.utils.efpl import *
+from wknml import *
 from numpy import uint32
+import numpy as np
+import h5py
+import wknml
 import pytest
 
 def test_imports():
     pass
+
+def test_calc_supervoxel_eftpl(tmp_path):
+    dummy_data = np.random.randint(100, size=(10, 10, 10))
+    with h5py.File(tmp_path / 'test.h5', 'w') as h5file:
+        h5file.create_dataset('with_background/test_data/labels', data=dummy_data)
+
+    nml = util_get_nml()
+
+    with open(tmp_path / "test.nml", "wb") as f:
+        wknml.write_nml(f, nml)
+
+    calc_supervoxel_eftpl(tmp_path / 'test.nml', tmp_path / 'test.h5')
+
+    return
+
+def test_calc_efpl_outside_roi():
+    import wknml
+    nml = wknml.NML(
+        parameters=wknml.NMLParameters(
+            name='',
+            scale=(1, 1, 1),
+        ),
+        trees=[
+            wknml.Tree(
+                id=0,
+                color=(255, 255, 0, 1),
+                name='',
+                nodes=[
+                    wknml.Node(id=4, position=(2, 1, 1), radius=1),
+                    wknml.Node(id=5, position=(3, 1, 1), radius=1),
+                    wknml.Node(id=6, position=(20, 1, 1), radius=1)
+                ],
+                edges=[
+                    wknml.Edge(source=4, target=5),
+                    wknml.Edge(source=5, target=6),
+
+                ],
+            ),
+        ],
+        branchpoints=[],
+        comments=[],
+        groups=[],
+    )
+    
+    Vlbls = np.ones((5, 5, 5), dtype=np.uint32)
+    dataset_start = np.zeros((1, 3), dtype=int)
+
+    calc_eftpl(nml, Vlbls, dataset_start)
+
 
 
 def test_calc_efpl_simple():
@@ -88,9 +141,7 @@ def util_get_nml():
         ),
         trees=trees,
         branchpoints=[],
-        comments=[{'loadcorner':(0,0,0),
-            'loadsize':(5, 5, 5),
-            }],
+        comments=[],
         groups=[],
     )
     


### PR DESCRIPTION
`emdrp/emdrp/scripts/calculate_efpl.py`: Python cmd program which calculates the eftpl for a hdf5 supervoxel file and saves the results as csv.

During the calculation I realized that we (somehow) can not assume 'clean' nml data:

1. "empty" trees without edges and/or nodes are possible
2. Nodes outside the ROI are possible
3. Edges which point to nodes outside the ROI are possible